### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/Generators/HilbertCurveGenerator.java
+++ b/src/main/java/Generators/HilbertCurveGenerator.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -100,9 +101,9 @@ public class HilbertCurveGenerator implements GcodeGenerator {
 			String outputFile = System.getProperty("user.dir") + "/" + "TEMP.NGC";
 			System.out.println("output file = "+outputFile);
 			OutputStream output = new FileOutputStream(outputFile);
-			output.write(new String("G28\n").getBytes());
-			output.write(new String("G90\n").getBytes());
-			output.write(new String("G54 X-30 Z-"+tool_offset_z+"\n").getBytes());
+			output.write(new String("G28\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G90\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G54 X-30 Z-"+tool_offset_z+"\n").getBytes(StandardCharsets.UTF_8));
 			
 			turtle_x=0;
 			turtle_y=0;
@@ -111,32 +112,32 @@ public class HilbertCurveGenerator implements GcodeGenerator {
 			turtle_step = (float)((xmax-xmin) / (Math.pow(2, order)));
 
 			// Draw bounding box
-			output.write(new String("G90\n").getBytes());
-			output.write(new String("G0 Z"+z_up+"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 Z"+z_down+"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymin+"\n").getBytes());
-			output.write(new String("G0 X"+xmin+" Y"+ymin+"\n").getBytes());
-			output.write(new String("G0 X"+xmin+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 Z"+z_up+"\n").getBytes());
+			output.write(new String("G90\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 Z"+z_up+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 Z"+z_down+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+xmax+" Y"+ymin+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+xmin+" Y"+ymin+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+xmin+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 Z"+z_up+"\n").getBytes(StandardCharsets.UTF_8));
 
 			// move to starting position
-			output.write(new String("G91\n").getBytes());
-			output.write(new String("G0 X"+(-turtle_step/2)+" Y"+(-turtle_step/2)+"\n").getBytes());
+			output.write(new String("G91\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 X"+(-turtle_step/2)+" Y"+(-turtle_step/2)+"\n").getBytes(StandardCharsets.UTF_8));
 						
 			// do the curve
-			output.write(new String("G90\n").getBytes());
-			output.write(new String("G0 Z"+z_down+"\n").getBytes());
+			output.write(new String("G90\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 Z"+z_down+"\n").getBytes(StandardCharsets.UTF_8));
 			
-			output.write(new String("G91\n").getBytes());
+			output.write(new String("G91\n").getBytes(StandardCharsets.UTF_8));
 			hilbert(output,order);
 			
-			output.write(new String("G90\n").getBytes());
-			output.write(new String("G0 Z"+z_up+"\n").getBytes());
+			output.write(new String("G90\n").getBytes(StandardCharsets.UTF_8));
+			output.write(new String("G0 Z"+z_up+"\n").getBytes(StandardCharsets.UTF_8));
 
 			// finish up
-			output.write(new String("G28\n").getBytes());
+			output.write(new String("G28\n").getBytes(StandardCharsets.UTF_8));
 			
         	output.flush();
 	        output.close();
@@ -197,6 +198,6 @@ public class HilbertCurveGenerator implements GcodeGenerator {
     	//turtle_x += turtle_dx * distance;
     	//turtle_y += turtle_dy * distance;
     	//output.write(new String("G0 X"+(turtle_x)+" Y"+(turtle_y)+"\n").getBytes());
-    	output.write(new String("G0 X"+(turtle_dx*turtle_step)+" Y"+(turtle_dy*turtle_step)+"\n").getBytes());
+    	output.write(new String("G0 X"+(turtle_dx*turtle_step)+" Y"+(turtle_dy*turtle_step)+"\n").getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/DeltaRobot3/DeltaRobot3.java
@@ -8,6 +8,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import com.jogamp.opengl.GL2;
@@ -530,9 +531,9 @@ extends RobotWithConnection {
 			URL url = new URL("https://marginallyclever.com/deltarobot_getuid.php");
 			URLConnection conn = url.openConnection();
 			try (
-					final InputStream connectionInputStream = conn.getInputStream();
-					final Reader inputStreamReader = new InputStreamReader(connectionInputStream);
-					final BufferedReader rd = new BufferedReader(inputStreamReader)
+                    final InputStream connectionInputStream = conn.getInputStream();
+                    final Reader inputStreamReader = new InputStreamReader(connectionInputStream, StandardCharsets.UTF_8);
+                    final BufferedReader rd = new BufferedReader(inputStreamReader)
 					) {
 				String line = rd.readLine();
 				new_uid = Long.parseLong(line);

--- a/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/EvilMinion/EvilMinionRobot.java
@@ -18,6 +18,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -962,9 +963,9 @@ extends RobotWithConnection {
 			URL url = new URL("https://marginallyclever.com/evil_minion_getuid.php");
 			URLConnection conn = url.openConnection();
 			try (
-					final InputStream connectionInputStream = conn.getInputStream();
-					final Reader inputStreamReader = new InputStreamReader(connectionInputStream);
-					final BufferedReader rd = new BufferedReader(inputStreamReader)
+                    final InputStream connectionInputStream = conn.getInputStream();
+                    final Reader inputStreamReader = new InputStreamReader(connectionInputStream, StandardCharsets.UTF_8);
+                    final BufferedReader rd = new BufferedReader(inputStreamReader)
 					) {
 				String line = rd.readLine();
 				new_uid = Long.parseLong(line);

--- a/src/main/java/com/marginallyclever/robotOverlord/Log.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Log.java
@@ -1,9 +1,9 @@
 package com.marginallyclever.robotOverlord;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,7 +60,7 @@ public class Log {
 	 * @param msg
 	 */
 	public static void write(String msg) {
-		try (Writer fileWriter = new FileWriter("log.html", true)) {
+		try (Writer fileWriter = new OutputStreamWriter(new FileOutputStream("log.html", true), StandardCharsets.UTF_8)) {
 			PrintWriter logToFile = new PrintWriter(fileWriter);
 			logToFile.write(msg);
 			logToFile.flush();

--- a/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/MantisRobot/MantisRobot.java
@@ -18,6 +18,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -1084,9 +1085,9 @@ extends RobotWithConnection {
 			URL url = new URL("https://marginallyclever.com/evil_minion_getuid.php");
 			URLConnection conn = url.openConnection();
 			try (
-					final InputStream connectionInputStream = conn.getInputStream();
-					final Reader inputStreamReader = new InputStreamReader(connectionInputStream);
-					final BufferedReader rd = new BufferedReader(inputStreamReader)
+                    final InputStream connectionInputStream = conn.getInputStream();
+                    final Reader inputStreamReader = new InputStreamReader(connectionInputStream, StandardCharsets.UTF_8);
+                    final BufferedReader rd = new BufferedReader(inputStreamReader)
 					) {
 				String line = rd.readLine();
 				new_uid = Long.parseLong(line);

--- a/src/main/java/com/marginallyclever/robotOverlord/RobotOverlord.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RobotOverlord.java
@@ -26,6 +26,7 @@ import java.io.ObjectOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.prefs.Preferences;
 
 import javax.swing.JFileChooser;
@@ -445,7 +446,7 @@ implements ActionListener, MouseListener, MouseMotionListener, KeyListener, GLEv
 			HttpURLConnection conn = (HttpURLConnection) github.openConnection();
 			conn.setInstanceFollowRedirects(false);  //you still need to handle redirect manully.
 			HttpURLConnection.setFollowRedirects(false);
-			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
 
 			String inputLine;
 			if ((inputLine = in.readLine()) != null) {

--- a/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2.java
@@ -8,6 +8,7 @@ import java.io.ObjectInputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import com.jogamp.opengl.GL2;
@@ -510,9 +511,9 @@ extends RobotWithConnection
 				URL url = new URL("https://marginallyclever.com/stewart_platform_getuid.php");
 				URLConnection conn = url.openConnection();
 				try (
-						final InputStream connectionInputStream = conn.getInputStream();
-						final Reader inputStreamReader = new InputStreamReader(connectionInputStream);
-						final BufferedReader rd = new BufferedReader(inputStreamReader)
+                        final InputStream connectionInputStream = conn.getInputStream();
+                        final Reader inputStreamReader = new InputStreamReader(connectionInputStream, StandardCharsets.UTF_8);
+                        final BufferedReader rd = new BufferedReader(inputStreamReader)
 						) {
 					String line = rd.readLine();
 					new_uid = Long.parseLong(line);

--- a/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.FloatBuffer;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.prefs.Preferences;
 
@@ -1569,9 +1570,9 @@ implements ActionListener {
 			URL url = new URL("https://marginallyclever.com/evil_minion_getuid.php");
 			URLConnection conn = url.openConnection();
 			try (
-					final InputStream connectionInputStream = conn.getInputStream();
-					final Reader inputStreamReader = new InputStreamReader(connectionInputStream);
-					final BufferedReader rd = new BufferedReader(inputStreamReader)
+                    final InputStream connectionInputStream = conn.getInputStream();
+                    final Reader inputStreamReader = new InputStreamReader(connectionInputStream, StandardCharsets.UTF_8);
+                    final BufferedReader rd = new BufferedReader(inputStreamReader)
 					) {
 				String line = rd.readLine();
 				new_uid = Long.parseLong(line);

--- a/src/main/java/com/marginallyclever/robotOverlord/communications/SerialConnection.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/communications/SerialConnection.java
@@ -4,6 +4,7 @@ import jssc.*;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import javax.swing.JScrollPane;
@@ -73,7 +74,7 @@ implements SerialPortEventListener, AbstractConnection {
             	int len = events.getEventValue();
 				byte [] buffer = serialPort.readBytes(len);
 				if( len>0 ) {
-					rawInput = new String(buffer,0,len);
+					rawInput = new String(buffer,0,len, StandardCharsets.UTF_8);
 //					Log(rawInput);
 					inputBuffer+=rawInput;
 					// each line ends with a \n.
@@ -113,7 +114,7 @@ implements SerialPortEventListener, AbstractConnection {
 			}
 			log(command+NL);
 			line+=NL;
-			serialPort.writeBytes(line.getBytes());
+			serialPort.writeBytes(line.getBytes(StandardCharsets.UTF_8));
 			waitingForCue=true;
 		}
 		catch(IndexOutOfBoundsException e1) {}

--- a/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/model/Model.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.FloatBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -89,7 +90,7 @@ public class Model implements Serializable {
 		try {
 			// check if the file is binary or ASCII
 			zipFile = new ZipInputStream(getInputStream(zipName));
-			isr = new InputStreamReader(zipFile);
+			isr = new InputStreamReader(zipFile, StandardCharsets.UTF_8);
 			
 		    while((entry = zipFile.getNextEntry())!=null) {
 		        if( entry.getName().equals(fname) ) {
@@ -106,7 +107,7 @@ public class Model implements Serializable {
 		    
 		    // now load the file enough to initialize
 			zipFile = new ZipInputStream(getInputStream(zipName));
-			isr = new InputStreamReader(zipFile);
+			isr = new InputStreamReader(zipFile, StandardCharsets.UTF_8);
 			
 		    while((entry = zipFile.getNextEntry())!=null) {
 		        if( entry.getName().equals(fname) ) {
@@ -122,7 +123,7 @@ public class Model implements Serializable {
 
 		    if(!isBinary) {
 				zipFile = new ZipInputStream(getInputStream(zipName));
-				isr = new InputStreamReader(zipFile);
+				isr = new InputStreamReader(zipFile, StandardCharsets.UTF_8);
 				
 			    while((entry = zipFile.getNextEntry())!=null) {
 			        if( entry.getName().equals(fname) ) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat