### PR TITLE
squid:S1905 - Redundant casts should not be used

### DIFF
--- a/src/main/java/Generators/YourMessageHereGenerator.java
+++ b/src/main/java/Generators/YourMessageHereGenerator.java
@@ -385,7 +385,7 @@ public class YourMessageHereGenerator implements GcodeGenerator {
 	}
 	
 	public void TextFindCharsPerLine(float width) {
-		chars_per_line=(int)Math.floor( (float)(width - padding*2.0f) / (float)(letter_width+kerning) );
+		chars_per_line=(int)Math.floor( (width - padding*2.0f) / (letter_width+kerning) );
 		//System.out.println("MAX="+chars_per_line);
 	}
 	

--- a/src/main/java/com/marginallyclever/robotOverlord/IntersectionTester.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/IntersectionTester.java
@@ -75,8 +75,8 @@ public class IntersectionTester {
 	    }
 
 	    // finally do the division to get sc and tc
-	    sc = ((float)Math.abs(sN) < SMALL_NUM ? 0.0f : sN / sD);
-	    tc = ((float)Math.abs(tN) < SMALL_NUM ? 0.0f : tN / tD);
+	    sc = Math.abs(sN) < SMALL_NUM ? 0.0f : sN / sD;
+	    tc = Math.abs(tN) < SMALL_NUM ? 0.0f : tN / tD;
 
 	    // get the difference of the two closest points
 	    //Vector   dP = w + (sc * u) - (tc * v);  // =  L1(sc) - L2(tc)

--- a/src/main/java/com/marginallyclever/robotOverlord/PrimitiveSolids.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/PrimitiveSolids.java
@@ -205,14 +205,14 @@ public class PrimitiveSolids {
 				for(int k=-grid_size;k<=grid_size;k+=grid_space) {
 					v = (float)(Math.abs(k));
 					u = (float)(Math.abs(i));
-					w = (grid_size*grid_size)-(float)(u*u+v*v);
+					w = (grid_size*grid_size) - (u*u+v*v);
 					gl2.glColor4f(0.2f,0.2f,0.2f,w/(grid_size*grid_size*2.5f));
 					
 					gl2.glVertex3f(i,k           ,0);
 					gl2.glVertex3f(i,k+grid_space,0);					
 
 					u = (float)(Math.abs(j));
-					w = (grid_size*grid_size)-(float)(u*u+v*v);
+					w = (grid_size*grid_size)-(u*u+v*v);
 					gl2.glColor4f(0.2f,0.2f,0.2f,w/(grid_size*grid_size*2.5f));
 
 					gl2.glVertex3f(k           ,j,0);

--- a/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/RotaryStewartPlatform2/RotaryStewartPlatform2MotionState.java
@@ -220,8 +220,8 @@ public class RotaryStewartPlatform2MotionState implements Serializable {
 		    RotaryStewartPlatform2Arm arm = this.arms[i];
 		    
 		    // project wrist position onto plane of bicep (wop)
-		    ortho.x=(float)Math.cos((int)(i/2)*Math.PI*2.0f/3.0f);
-		    ortho.y=(float)Math.sin((int)(i/2)*Math.PI*2.0f/3.0f);
+		    ortho.x=(float)Math.cos((i/2)*Math.PI*2.0f/3.0f);
+		    ortho.y=(float)Math.sin((i/2)*Math.PI*2.0f/3.0f);
 		    ortho.z=0;
 		    
 		    //w = arm.wrist - arm.shoulder

--- a/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
+++ b/src/main/java/com/marginallyclever/robotOverlord/Spidee/Spidee.java
@@ -1160,7 +1160,7 @@ implements ActionListener {
 
 	  // turn
 	  if( turn_direction != 0 ) {
-	    turn_direction= (float)Math.max( Math.min( turn_direction, 180*dt ), -180*dt );
+	    turn_direction= Math.max( Math.min( turn_direction, 180*dt ), -180*dt );
 	    float turn = (float)Math.toRadians(turn_direction * turn_stride_length) * dt * move_body_scale / 6.0f;
 
 	    float c= (float)Math.cos( turn );
@@ -1283,8 +1283,8 @@ implements ActionListener {
 
 	  float x1 = gc1 - (float)Math.floor( gc1 );
 	  float x2 = gc2 - (float)Math.floor( gc2 );
-	  float step1 = (float)Math.max( 0, x1 );
-	  float step2 = (float)Math.max( 0, x2 );
+	  float step1 = Math.max( 0, x1 );
+	  float step2 = Math.max( 0, x2 );
 	  int leg1 = (int)Math.floor( gc1 ) % 3;
 	  int leg2 = (int)Math.floor( gc2 ) % 3;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1905 - Redundant casts should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905

Please let me know if you have any questions.

M-Ezzat